### PR TITLE
Refactor flask routes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -99,7 +99,7 @@ def create_app(config_class=Config):
     compress.init_app(app)
     csrf.init_app(app)
     limiter.init_app(app)
-    talisman.init_app(app, 
+    talisman.init_app(app,
                       content_security_policy=csp, 
                       permissions_policy=permissions_policy, 
                       content_security_policy_nonce_in=["script-src"], 
@@ -107,7 +107,7 @@ def create_app(config_class=Config):
                       session_cookie_secure=True,
                       session_cookie_http_only=True,
                       session_cookie_samesite="Strict",)
-    
+
     WTFormsHelpers(app)
 
     # Create static asset bundles
@@ -119,8 +119,8 @@ def create_app(config_class=Config):
         assets.register("js", js)
 
     # Register blueprints
-    from app.demos import bp as demo_bp
-    from app.main import bp as main_bp
+    from app.demos.routes import bp as demo_bp
+    from app.main.routes import bp as main_bp
 
     app.register_blueprint(demo_bp)
     app.register_blueprint(main_bp)

--- a/app/demos/__init__.py
+++ b/app/demos/__init__.py
@@ -1,5 +1,0 @@
-from flask import Blueprint
-
-bp = Blueprint("demos", __name__, template_folder="../templates/demos")
-
-from app.demos import routes  # noqa: E402,F401

--- a/app/demos/routes.py
+++ b/app/demos/routes.py
@@ -1,11 +1,13 @@
 import os
 
 import yaml
-from flask import flash, redirect, render_template, url_for
+from flask import Blueprint, flash, redirect, render_template, url_for
 from werkzeug.exceptions import NotFound
 
-from app.demos import bp
 from app.demos.forms import AutocompleteForm, BankDetailsForm, ConditionalRevealForm, CreateAccountForm, KitchenSinkForm
+
+
+bp = Blueprint("demos", __name__, template_folder="../templates/demos")
 
 
 @bp.route("/components", methods=["GET"])

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,5 +1,0 @@
-from flask import Blueprint
-
-bp = Blueprint("main", __name__, template_folder="../templates/main")
-
-from app.main import routes  # noqa: E402,F401

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,9 +1,11 @@
-from flask import flash, json, make_response, redirect, render_template, request
+from flask import Blueprint, flash, json, make_response, redirect, render_template, request
 from flask_wtf.csrf import CSRFError
 from werkzeug.exceptions import HTTPException
 
-from app.main import bp
 from app.main.forms import CookiesForm
+
+
+bp = Blueprint("main", __name__, template_folder="../templates/main")
 
 
 @bp.route("/", methods=["GET"])


### PR DESCRIPTION
Routes are now created within `app/route.py` rather than `app/__init__.py`.
This resolves the issue where a 'magic' import was being placed within the __init__ file to register routes early.
